### PR TITLE
Entity on a DepositLineDetail should be of type BaseReference

### DIFF
--- a/lib/quickbooks/model/deposit_line_detail.rb
+++ b/lib/quickbooks/model/deposit_line_detail.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Model
     class DepositLineDetail < BaseModel
 
-      xml_accessor :entity, :from => 'Entity', :as => Entity
+      xml_accessor :entity, :from => 'Entity', :as => BaseReference
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :account_ref, :from => 'AccountRef', :as => BaseReference
       xml_accessor :payment_method_ref, :from => 'PaymentMethodRef', :as => BaseReference


### PR DESCRIPTION
As per the Intuit developer docs. An entity is basically a BaseReference.

Link to [docs](https://developer.intuit.com/docs/api/accounting/Deposit) and [screenshot](https://www.dropbox.com/s/mbp2raoujzinmzw/Screenshot%202016-04-11%2013.48.03.png?dl=0) attached. I also verified this and it works.
